### PR TITLE
Fixes build  when opt. dependency GPM is missing.

### DIFF
--- a/source/linux/gpminput.cpp
+++ b/source/linux/gpminput.cpp
@@ -93,7 +93,7 @@ bool GpmInput::getEvent(TEvent &ev)
 
 #else
 
-GpmInput::GpmInput() {}
+GpmInput::GpmInput(): cursor(ScreenCursor::DrawStyle::Negative) {}
 GpmInput::~GpmInput() {}
 int GpmInput::getButtonCount() { return 0; }
 bool GpmInput::getEvent(TEvent &ev) { return false; }


### PR DESCRIPTION
Magiblot, thanks for the fantastic work on Turbo Vision.

I didn't have the 'gpm' optional dependency on my system (a Ubuntu 20.04). In this scenario, a compilation error happens on line 96 of 'gpminput.ccp'.

This pull request contains a possible fix for the problem.