### PR TITLE
Help system fixes

### DIFF
--- a/examples/tvhc/tvhc.cpp
+++ b/examples/tvhc/tvhc.cpp
@@ -849,7 +849,7 @@ void recordTopicDefinitions( TTopicDefinition *p, THelpFile& helpFile )
 {
     while (p != 0)
         {
-        resolveReference(p->topic, p->value, *(helpFile.stream));
+        resolveReference(p->topic, p->value, dynamic_cast<fpstream&>(*(helpFile.stream)));
         helpFile.recordPositionInIndex(p->value);
         p = p->next;
         }

--- a/examples/tvhc/tvhc.h
+++ b/examples/tvhc/tvhc.h
@@ -24,7 +24,7 @@ const int MAXSIZE = 300;
 const int MAXSTRSIZE=256;
 const int MAXHELPTOPICID=16379;
 const char commandChar[] = ".";
-const int bufferSize = 4096;
+const int bufferSize = 1000000;
 
 enum State { undefined, wrapping, notWrapping };
 

--- a/examples/tvhc/tvhc.h
+++ b/examples/tvhc/tvhc.h
@@ -20,7 +20,7 @@
 #endif  // __HELPBASE_H
 
 
-const int MAXSIZE = 80;
+const int MAXSIZE = 300;
 const int MAXSTRSIZE=256;
 const int MAXHELPTOPICID=16379;
 const char commandChar[] = ".";

--- a/include/tvision/helpbase.h
+++ b/include/tvision/helpbase.h
@@ -167,7 +167,7 @@ class THelpFile : public TObject
 
 public:
 
-    THelpFile( fpstream& s );
+    THelpFile( iopstream& s );
     virtual ~THelpFile();
 
     THelpTopic *getTopic( int );
@@ -175,7 +175,7 @@ public:
     void recordPositionInIndex( int );
     void putTopic( THelpTopic* );
 
-    fpstream *stream;
+    iopstream *stream;
     Boolean modified;
 
     THelpIndex *index;

--- a/source/tvision/helpbase.cpp
+++ b/source/tvision/helpbase.cpp
@@ -546,7 +546,7 @@ void THelpIndex::add( int i, int32_t val )
 
 // THelpFile
 
-THelpFile::THelpFile( fpstream&  s )
+THelpFile::THelpFile( iopstream&  s )
 {
     int32_t magic;
     int32_t size;


### PR DESCRIPTION
- tvhc: Increase the buffer size for the help file path. It was crashing on longer but still valid paths.
- tvhc: Increase the buffer size for topics. Converting to dynamic memory allocation would have been nice but I didn't want to delve deeply into the code. tmbasic needed this in order to stick the various third-party licenses into help topics.
- THelpFile: Allow in-memory streams instead of requiring the help file to come from a file. tmbasic uses this to link the help file directly into the executable instead of shipping a separate file.