### PR TITLE
make tvision work on FreeBSD

### DIFF
--- a/include/tvision/internal/platform.h
+++ b/include/tvision/internal/platform.h
@@ -1,6 +1,10 @@
 #ifndef PLATFORM_H
 #define PLATFORM_H
 
+#ifdef __FreeBSD__
+#undef wcwidth
+#endif
+
 #define Uses_TPoint
 #include <tvision/tv.h>
 #include <memory>


### PR DESCRIPTION
Under FreeBSD, the compiler complains in the wcwidth function, since it is defined as macro. To make tvision compile, this macro should be undefined.