### PR TITLE
Allow turning off precompiled headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ if ((CMAKE_VERSION VERSION_LESS "3.16.0") AND TV_LIBRARY_UNITY_BUILD)
     set(TV_LIBRARY_UNITY_BUILD OFF)
 endif()
 
-option(TV_OPTIMIZE_BUILD "Use CMake's Precompiled Headers" OFF)
+option(TV_OPTIMIZE_BUILD "Use CMake's Precompiled Headers" ON)
 if ((CMAKE_VERSION VERSION_LESS "3.16.0") AND TV_OPTIMIZE_BUILD)
     tv_message(WARNING "'TV_OPTIMIZE_BUILD' requested but only available in CMake 3.16.0 or newer.")
     set(TV_OPTIMIZE_BUILD OFF)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -175,7 +175,7 @@ install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/tvision" DESTINATION include)
 
 # Build optimization
 
-if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.16.0")
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.16.0" AND ${TV_OPTIMIZE_BUILD})
     # Enable precompiled headers.
     target_precompile_headers(${PROJECT_NAME} PRIVATE "${PROJECT_SOURCE_DIR}/include/pch.h")
 

--- a/source/platform/scrlife.cpp
+++ b/source/platform/scrlife.cpp
@@ -2,6 +2,8 @@
 
 #ifdef _TV_UNIX
 
+#include <initializer_list>
+
 #include <stdio.h>
 #include <fcntl.h>
 #include <io.h>


### PR DESCRIPTION
The documentation in the top-level `CMakeLists.txt` claims
that precompiled header generation can be turned off using
`TV_OPTIMIZE_BUILD`. However, this variable is currently
unused.

This patch contains the following:
1. Check the `TV_OPTIMIZE_BUILD` variable before
   creating the precompile headers targets
2. Turn on `TV_OPTIMIZE_BUILD` by default (which
   will make precompiled headers build by default,
   as is already the case today); this aligns with
   the documentation in the top-level `CMakeLists.txt`

**Testing**

* Builds suceeds with `TV_OPTIMIZE_BUILD` set ON and OFF