### PR TITLE
Fix alloc-dealloc mismatches reported by ASAN when running tvdir

### DIFF
--- a/examples/tvdir/tvdir.cpp
+++ b/examples/tvdir/tvdir.cpp
@@ -243,7 +243,7 @@ void TFilePane::newDir( const char *path ) {
 void TFilePane::deleteFiles() {
     short i;
     for (i=0;i<fileCount;i++)
-      delete files[i];
+      delete[] files[i];
     delete[] files;
     fileCount=0;
 }

--- a/source/tvision/toutline.cpp
+++ b/source/tvision/toutline.cpp
@@ -573,7 +573,7 @@ static Boolean countNode( TOutlineViewer* beingCounted, TNode* p, int level,
     len = strwidth(beingCounted->getText(p)) + strwidth(graph);
     if (updateMaxX < len)
       updateMaxX = len;
-    delete graph;
+    delete[] graph;
     return False;
 }
 


### PR DESCRIPTION
While integrating tvdir into one of my applications ASAN found a couple of mismatched new/delete calls. There may be more around but I haven't run ASAN on everything yet.

Following are the ASAN logs:
[asan.log.2.txt](https://github.com/magiblot/tvision/files/8465296/asan.log.2.txt)
[asan.log.1.txt](https://github.com/magiblot/tvision/files/8465297/asan.log.1.txt)

This patch simply turns the `delete` calls into `delete []`.

**Testing**

* Confirmed ASAN doesn't report these errors on tvdir anymore
* Confirmed tvdir is operational