### PR TITLE
fix for special shift bits generated by putty4far2l

### DIFF
--- a/source/platform/far2l.cpp
+++ b/source/platform/far2l.cpp
@@ -72,6 +72,18 @@ ParseResult parseFar2lInput(GetChBuf &buf, TEvent &ev, InputState &state) noexce
             memcpy(&kev.dwControlKeyState, &out[6],  4);
             memcpy(&kev.uChar.UnicodeChar, &out[10], 4);
 
+            // putty4far2l has its own special shift bits. we do not need them for now.
+            #define RIGHT_SHIFT_PRESSED   0x0400 // the right shift key is pressed.
+            #define LEFT_SHIFT_PRESSED    0x0200 // the left shift key is pressed.
+            if (kev.dwControlKeyState & RIGHT_SHIFT_PRESSED) {
+                kev.dwControlKeyState = kev.dwControlKeyState & !RIGHT_SHIFT_PRESSED;
+                kev.dwControlKeyState = kev.dwControlKeyState | SHIFT_PRESSED;
+            }
+            if (kev.dwControlKeyState & LEFT_SHIFT_PRESSED) {
+                kev.dwControlKeyState = kev.dwControlKeyState & !LEFT_SHIFT_PRESSED;
+                kev.dwControlKeyState = kev.dwControlKeyState | SHIFT_PRESSED;
+            }
+
             if (uint16_t keyCode = virtualKeyCodeToKeyCode[kev.wVirtualKeyCode])
             {
                 kev.wVirtualScanCode = keyCode >> 8;


### PR DESCRIPTION
putty4far2l supports special bits for distinguishing left and right shift as proposed here: https://github.com/microsoft/terminal/issues/337

but tvision does not supports those bits for now, so shift+some_key combinations become broken.

this PR fixes that.

see [#47](https://github.com/magiblot/turbo/issues/47)