### PR TITLE
quick corrections for UNICODE build: use the ANSI Win32 APIs

### DIFF
--- a/source/platform/stdioctl.cpp
+++ b/source/platform/stdioctl.cpp
@@ -216,7 +216,7 @@ StdioCtl::StdioCtl() noexcept
     }
     if (!isValid(cn[input].handle))
     {
-        cn[input].handle = CreateFile(
+        cn[input].handle = CreateFileA(
             "CONIN$",
             GENERIC_READ | GENERIC_WRITE,
             FILE_SHARE_READ,
@@ -228,7 +228,7 @@ StdioCtl::StdioCtl() noexcept
     }
     if (!isValid(cn[startupOutput].handle))
     {
-        cn[startupOutput].handle = CreateFile(
+        cn[startupOutput].handle = CreateFileA(
             "CONOUT$",
             GENERIC_READ | GENERIC_WRITE,
             FILE_SHARE_WRITE,
@@ -279,7 +279,7 @@ void StdioCtl::write(const char *data, size_t bytes) const noexcept
     // Writing 0 bytes causes the cursor to become invisible for a short time
     // in old versions of the Windows console.
     if (bytes != 0)
-        WriteConsole(out(), data, bytes, nullptr, nullptr);
+        WriteConsoleA(out(), data, bytes, nullptr, nullptr);
 }
 
 TPoint StdioCtl::getSize() const noexcept

--- a/source/platform/win32con.cpp
+++ b/source/platform/win32con.cpp
@@ -18,7 +18,7 @@ namespace tvision
 
 static bool isWine() noexcept
 {
-    return GetProcAddress(GetModuleHandle("ntdll"), "wine_get_version");
+    return GetProcAddress(GetModuleHandleA("ntdll"), "wine_get_version");
 }
 
 Win32ConsoleStrategy &Win32ConsoleStrategy::create() noexcept
@@ -327,7 +327,7 @@ void Win32Display::clearScreen() noexcept
     BYTE attr = 0x07;
     DWORD read;
     FillConsoleOutputAttribute(io.out(), attr, length, coord, &read);
-    FillConsoleOutputCharacter(io.out(), ' ', length, coord, &read);
+    FillConsoleOutputCharacterA(io.out(), ' ', length, coord, &read);
     lastAttr = attr;
 }
 


### PR DESCRIPTION
quick corrections for UNICODE build: use the ANSI Win32 APIs where applicable. Before this change the UNICODE build would deliver some rare cruft on the console; after this change at least the hello app functions as expected, once again.

(Background: UNICODE build was done using my own MSVC2022 project setup rig, which compiles everything in UNICODE (wide char) mode for Windows.)

> TODO for later? Make tvision do the right thing and NOT use the *A Win32 APIs? 🤔 Would that be useful at all? 🤔 