### PR TITLE
Convert variable definitions in *.h files into enums

### DIFF
--- a/include/tvision/app.h
+++ b/include/tvision/app.h
@@ -179,30 +179,33 @@ inline opstream& operator << ( opstream& os, TDeskTop* cl )
 
 // Note: range $FF00 - $FFFF of help contexts are reserved by Borland
 
-const unsigned short hcNew          = 0xFF01;
-const unsigned short hcOpen         = 0xFF02;
-const unsigned short hcSave         = 0xFF03;
-const unsigned short hcSaveAs       = 0xFF04;
-const unsigned short hcSaveAll      = 0xFF05;
-const unsigned short hcChangeDir    = 0xFF06;
-const unsigned short hcDosShell     = 0xFF07;
-const unsigned short hcExit         = 0xFF08;
+enum : unsigned short {
 
-const unsigned short hcUndo         = 0xFF10;
-const unsigned short hcCut          = 0xFF11;
-const unsigned short hcCopy         = 0xFF12;
-const unsigned short hcPaste        = 0xFF13;
-const unsigned short hcClear        = 0xFF14;
+    hcNew          = 0xFF01,
+    hcOpen         = 0xFF02,
+    hcSave         = 0xFF03,
+    hcSaveAs       = 0xFF04,
+    hcSaveAll      = 0xFF05,
+    hcChangeDir    = 0xFF06,
+    hcDosShell     = 0xFF07,
+    hcExit         = 0xFF08,
 
-const unsigned short hcTile         = 0xFF20;
-const unsigned short hcCascade      = 0xFF21;
-const unsigned short hcCloseAll     = 0xFF22;
-const unsigned short hcResize       = 0xFF23;
-const unsigned short hcZoom         = 0xFF24;
-const unsigned short hcNext         = 0xFF25;
-const unsigned short hcPrev         = 0xFF26;
-const unsigned short hcClose        = 0xFF27;
+    hcUndo         = 0xFF10,
+    hcCut          = 0xFF11,
+    hcCopy         = 0xFF12,
+    hcPaste        = 0xFF13,
+    hcClear        = 0xFF14,
 
+    hcTile         = 0xFF20,
+    hcCascade      = 0xFF21,
+    hcCloseAll     = 0xFF22,
+    hcResize       = 0xFF23,
+    hcZoom         = 0xFF24,
+    hcNext         = 0xFF25,
+    hcPrev         = 0xFF26,
+    hcClose        = 0xFF27
+
+};
 
 class _FAR TStatusLine;
 class _FAR TMenuBar;
@@ -240,14 +243,14 @@ protected:
 /*      32-63 = TDialog                                                   */
 /* ---------------------------------------------------------------------- */
 
-const int
+enum : int {
 
 //  TApplication palette entries
 
     apColor      = 0,
     apBlackWhite = 1,
-    apMonochrome = 2;
-
+    apMonochrome = 2
+};
 class _FAR TDialog;
 class _FAR TWindow;
 class _FAR TTimerQueue;

--- a/include/tvision/buffers.h
+++ b/include/tvision/buffers.h
@@ -24,7 +24,7 @@
 #if defined( Uses_TVMemMgr ) && !defined( __TVMemMgr )
 #define __TVMemMgr
 
-const int DEFAULT_SAFETY_POOL_SIZE = 4096;
+enum : int { DEFAULT_SAFETY_POOL_SIZE = 4096 };
 
 class TBufListEntry
 {

--- a/include/tvision/colors.h
+++ b/include/tvision/colors.h
@@ -265,11 +265,12 @@ inline TColorRGB XTerm256toRGB(uint8_t idx)
 // In a terminal emulator, the 'default color' is the color of text that has no
 // display attributes (bold, color...) enabled.
 
-const uchar
+enum : uchar {
     ctDefault       = 0x0,  // Terminal default.
     ctBIOS          = 0x1,  // TColorBIOS.
     ctRGB           = 0x2,  // TColorRGB.
-    ctXTerm         = 0x3;  // TColorXTerm.
+    ctXTerm         = 0x3   // TColorXTerm.
+};
 
 struct TColorDesired
 {
@@ -454,7 +455,7 @@ constexpr inline void TColorDesired::bitCast(uint32_t val)
 // colors set to 'default'. Therefore, a zero-initialized TColorAttr produces
 // visible text.
 
-const ushort
+enum : ushort {
 
 // TColorAttr Style masks
 
@@ -467,7 +468,8 @@ const ushort
 
 // Private masks
 
-    slNoShadow      = 0x200; // Don't draw window shadows over this cell.
+    slNoShadow      = 0x200  // Don't draw window shadows over this cell.
+};
 
 struct TAttrPair;
 

--- a/include/tvision/colorsel.h
+++ b/include/tvision/colorsel.h
@@ -23,14 +23,14 @@
 #if !defined( __COLOR_COMMAND_CODES )
 #define __COLOR_COMMAND_CODES
 
-const int
+enum : int {
   cmColorForegroundChanged = 71,
   cmColorBackgroundChanged = 72,
   cmColorSet               = 73,
   cmNewColorItem           = 74,
   cmNewColorIndex          = 75,
-  cmSaveColorIndex         = 76;
-
+  cmSaveColorIndex         = 76
+};
 #endif  // __COLOR_COMMAND_CODES
 
 class _FAR TColorItem;

--- a/include/tvision/config.h
+++ b/include/tvision/config.h
@@ -21,13 +21,14 @@
 #include <limits.h>
 #endif  // __LIMITS_H
 
-const int eventQSize = 16;
-const int keyEventQSize = 3;
-const int maxCollectionSize = (int)(( (unsigned long) UINT_MAX - 16)/sizeof( void * ));
+enum : int {
+    eventQSize = 16,
+    keyEventQSize = 3,
+    maxCollectionSize = (int)(( (unsigned long) UINT_MAX - 16)/sizeof( void * )),
 
-const int maxViewWidth = 132;
+    maxViewWidth = 132,
 
-const int maxFindStrLen    = 80;
-const int maxReplaceStrLen = 80;
-
+    maxFindStrLen    = 80,
+    maxReplaceStrLen = 80
+};
 #endif  // __CONFIG_H

--- a/include/tvision/dialogs.h
+++ b/include/tvision/dialogs.h
@@ -25,15 +25,15 @@
 #if !defined( __BUTTON_TYPE )
 #define __BUTTON_TYPE
 
-const int
+enum : int {
     bfNormal    = 0x00,
     bfDefault   = 0x01,
     bfLeftJust  = 0x02,
     bfBroadcast = 0x04,
     bfGrabFocus = 0x08,
 
-    cmRecordHistory = 60;
-
+    cmRecordHistory = 60
+};
 #endif  // __BUTTON_TYPE
 
 /* ---------------------------------------------------------------------- */
@@ -91,11 +91,11 @@ const int
 
 #define cpDialog cpGrayDialog
 
-const int
+enum : int {
       dpBlueDialog = 0,
       dpCyanDialog = 1,
-      dpGrayDialog = 2;
-
+      dpGrayDialog = 2
+};
 class _FAR TRect;
 struct _FAR TEvent;
 class _FAR TValidator;
@@ -152,11 +152,11 @@ inline opstream& operator << ( opstream& os, TDialog* cl )
 #if defined( Uses_TInputLine ) && !defined( __TInputLine )
 #define __TInputLine
 
-const ushort
+enum : ushort {
     ilMaxBytes = 0,
     ilMaxWidth = 1,
-    ilMaxChars = 2;
-
+    ilMaxChars = 2
+};
 class _FAR TRect;
 struct _FAR TEvent;
 class _FAR TValidator;
@@ -573,10 +573,12 @@ inline TCheckBoxes::TCheckBoxes( const TRect& bounds, TSItem *aStrings) noexcept
 #if defined( Uses_TMultiCheckBoxes ) && !defined( __TMultiCheckBoxes )
 #define __TMultiCheckBoxes
 
-const unsigned short cfOneBit       = 0x0101,
-                     cfTwoBits      = 0x0203,
-                     cfFourBits     = 0x040F,
-                     cfEightBits    = 0x08FF;
+enum : unsigned short {
+    cfOneBit       = 0x0101,
+    cfTwoBits      = 0x0203,
+    cfFourBits     = 0x040F,
+    cfEightBits    = 0x08FF
+};
 
 /* ---------------------------------------------------------------------- */
 /*      TMultiCheckBoxes                                                  */

--- a/include/tvision/editors.h
+++ b/include/tvision/editors.h
@@ -36,25 +36,29 @@
 #if !defined( __EDIT_COMMAND_CODES )
 #define __EDIT_COMMAND_CODES
 
-const int
+enum : int {
   ufUpdate = 0x01,
   ufLine   = 0x02,
-  ufView   = 0x04;
+  ufView   = 0x04
+};
 
-const int
+enum : int {
   smExtend = 0x01,
   smDouble = 0x02,
-  smTriple = 0x04;
+  smTriple = 0x04
+};
 
-const unsigned
-  sfSearchFailed = -0x01;
+enum : unsigned {
+  sfSearchFailed = (unsigned)-0x01
+};
 
-const int
+enum : int {
   cmFind        = 82,
   cmReplace     = 83,
-  cmSearchAgain = 84;
+  cmSearchAgain = 84
+};
 
-const int
+enum : int {
   cmCharLeft    = 500,
   cmCharRight   = 501,
   cmWordLeft    = 502,
@@ -81,9 +85,10 @@ const int
   cmUpdateTitle = 523,
   cmSelectAll   = 524,
   cmDelWordLeft = 525,
-  cmEncoding    = 526;
+  cmEncoding    = 526
+};
 
-const int
+enum : int {
   edOutOfMemory   = 0,
   edReadError     = 1,
   edWriteError    = 2,
@@ -94,18 +99,21 @@ const int
   edFind          = 7,
   edSearchFailed  = 8,
   edReplace       = 9,
-  edReplacePrompt = 10;
+  edReplacePrompt = 10
+};
 
-const int
+enum : int {
   efCaseSensitive   = 0x0001,
   efWholeWordsOnly  = 0x0002,
   efPromptOnReplace = 0x0004,
   efReplaceAll      = 0x0008,
   efDoReplace       = 0x0010,
-  efBackupFiles     = 0x0100;
+  efBackupFiles     = 0x0100
+};
 
-const int
-  maxLineLength = 256;
+enum : int {
+  maxLineLength = 256
+};
 
 #endif  // __EDIT_COMMAND_CODES
 

--- a/include/tvision/helpbase.h
+++ b/include/tvision/helpbase.h
@@ -17,7 +17,7 @@
 #if !defined( __HELPBASE_H )
 #define __HELPBASE_H
 
-const int32_t magicHeader = 0x46484246L; //"FBHF"
+enum : int32_t { magicHeader = 0x46484246L }; //"FBHF"
 
 #define cHelpViewer "\x06\x07\x08"
 #define cHelpWindow "\x80\x81\x82\x83\x84\x85\x86\x87"

--- a/include/tvision/internal/termdisp.h
+++ b/include/tvision/internal/termdisp.h
@@ -8,11 +8,12 @@ namespace tvision
 
 // Terminal quirk flags.
 
-const uint
+enum : uint {
     qfBoldIsBright  = 0x0001,
     qfBlinkIsBright = 0x0002,
     qfNoItalic      = 0x0004,
-    qfNoUnderline   = 0x0008;
+    qfNoUnderline   = 0x0008
+};
 
 enum TermCapColors : uint8_t
 {

--- a/include/tvision/msgbox.h
+++ b/include/tvision/msgbox.h
@@ -37,7 +37,7 @@ ushort inputBox( TStringView Title, TStringView aLabel, char *s, uchar limit ) n
 ushort inputBoxRect( const TRect &bounds, TStringView title,
                      TStringView aLabel, char *s, uchar limit ) noexcept;
 
-const int
+enum : int {
 
 //  Message box classes
 
@@ -55,8 +55,9 @@ const int
 
     mfYesNoCancel  = mfYesButton | mfNoButton | mfCancelButton,
                                     // Standard Yes, No, Cancel dialog
-    mfOKCancel     = mfOKButton | mfCancelButton;
+    mfOKCancel     = mfOKButton | mfCancelButton
                                     // Standard OK, Cancel dialog
+};
 
 class MsgBoxText
 {

--- a/include/tvision/outline.h
+++ b/include/tvision/outline.h
@@ -23,13 +23,15 @@
 #if defined( Uses_TOutlineViewer ) && !defined( __TOutlineViewer )
 #define __TOutlineViewer
 
-const int
+enum : int {
   ovExpanded = 0x01,
   ovChildren = 0x02,
-  ovLast     = 0x04;
+  ovLast     = 0x04
+};
 
-const int
-  cmOutlineItemSelected = 301;
+enum : int {
+  cmOutlineItemSelected = 301
+};
 
 class TNode
 {

--- a/include/tvision/stddlg.h
+++ b/include/tvision/stddlg.h
@@ -26,7 +26,7 @@
 #if !defined( __FILE_CMDS )
 #define __FILE_CMDS
 
-const int
+enum : int {
 
 //  Commands
 
@@ -41,7 +41,9 @@ const int
 
     cmFileFocused = 102,    // A new file was focused in the TFileList
     cmFileDoubleClicked     // A file was selected in the TFileList
-            = 103;
+            = 103
+};
+
 
 #endif  // __FILE_CMDS
 
@@ -375,17 +377,18 @@ inline opstream& operator << ( opstream& os, TFileInfoPane* cl )
 #if defined( Uses_TFileDialog ) && !defined( __TFileDialog )
 #define __TFileDialog
 
-const int
+enum : int {
     fdOKButton      = 0x0001,      // Put an OK button in the dialog
     fdOpenButton    = 0x0002,      // Put an Open button in the dialog
     fdReplaceButton = 0x0004,      // Put a Replace button in the dialog
     fdClearButton   = 0x0008,      // Put a Clear button in the dialog
     fdHelpButton    = 0x0010,      // Put a Help button in the dialog
-    fdNoLoadDir     = 0x0100;      // Do not load the current directory
+    fdNoLoadDir     = 0x0100       // Do not load the current directory
                                    // contents into the dialog at Init.
                                    // This means you intend to change the
                                    // WildCard by using SetData or store
                                    // the dialog on a stream.
+};
 
 #if !defined( __DIR_H )
 #include <tvision/compat/borland/dir.h>
@@ -650,10 +653,11 @@ inline TDirCollection *TDirListBox::list()
 #if defined( Uses_TChDirDialog ) && !defined( __TChDirDialog )
 #define __TChDirDialog
 
-const int
+enum : int {
     cdNormal     = 0x0000, // Option to use dialog immediately
     cdNoLoadDir  = 0x0001, // Option to init the dialog to store on a stream
-    cdHelpButton = 0x0002; // Put a help button in the dialog
+    cdHelpButton = 0x0002  // Put a help button in the dialog
+};
 
 struct _FAR TEvent;
 class _FAR TInputLine;

--- a/include/tvision/system.h
+++ b/include/tvision/system.h
@@ -24,51 +24,57 @@
 #if !defined( __EVENT_CODES )
 #define __EVENT_CODES
 
+enum : int {
+
 /* Event codes */
 
-const int evMouseDown = 0x0001;
-const int evMouseUp   = 0x0002;
-const int evMouseMove = 0x0004;
-const int evMouseAuto = 0x0008;
-const int evMouseWheel= 0x0020;
-const int evKeyDown   = 0x0010;
-const int evCommand   = 0x0100;
-const int evBroadcast = 0x0200;
+evMouseDown = 0x0001,
+evMouseUp   = 0x0002,
+evMouseMove = 0x0004,
+evMouseAuto = 0x0008,
+evMouseWheel= 0x0020,
+evKeyDown   = 0x0010,
+evCommand   = 0x0100,
+evBroadcast = 0x0200,
 
 /* Event masks */
 
-const int evNothing   = 0x0000;
-const int evMouse     = 0x002f;
-const int evKeyboard  = 0x0010;
-const int evMessage   = 0xFF00;
+evNothing   = 0x0000,
+evMouse     = 0x002f,
+evKeyboard  = 0x0010,
+evMessage   = 0xFF00,
 
 /* Mouse button state masks */
 
-const int mbLeftButton  = 0x01;
-const int mbRightButton = 0x02;
-const int mbMiddleButton= 0x04;
+mbLeftButton  = 0x01,
+mbRightButton = 0x02,
+mbMiddleButton= 0x04,
 
 /* Mouse wheel state masks */
 
-const int mwUp      = 0x01;
-const int mwDown    = 0x02;
-const int mwLeft    = 0x04;
-const int mwRight   = 0x08;
-
+mwUp      = 0x01,
+mwDown    = 0x02,
+mwLeft    = 0x04,
+mwRight   = 0x08,
+};
 /* Mouse event flags */
 
 #if !defined( __FLAT__ )
-const int meMouseMoved = 0x01;
-const int meDoubleClick = 0x02;
+enum : int {
+meMouseMoved = 0x01,
+meDoubleClick = 0x02,
+};
 #else
 #if !defined( __WINDOWS_H )
 #include <tvision/compat/windows/windows.h>
 #endif
-const int meMouseMoved = MOUSE_MOVED;       // NT values from WINDOWS.H
-const int meDoubleClick = DOUBLE_CLICK;
+enum : int {
+meMouseMoved = MOUSE_MOVED,       // NT values from WINDOWS.H
+meDoubleClick = DOUBLE_CLICK,
+};
 #endif
 // 0x04 and 0x08 are reserved by NT (MOUSE_WHEELED, MOUSE_HWHEELED).
-const int meTripleClick = 0x10;
+enum : int {meTripleClick = 0x10};
 
 #endif  // __EVENT_CODES
 

--- a/include/tvision/tkeys.h
+++ b/include/tvision/tkeys.h
@@ -40,7 +40,7 @@
 // These constants do not cover all possible combinations of the Shift, Ctrl
 // and Alt modifiers. For that purpose, see the TKey class below.
 
-const ushort
+enum : ushort {
 
 // Control keys
 
@@ -132,7 +132,7 @@ const ushort
     kbNumState    = 0x0020,
     kbCapsState   = 0x0040,
     kbInsState    = 0x0080,
-    kbPaste       = 0x0100;
+    kbPaste       = 0x0100
 #else
     kbLeftShift   = SHIFT_PRESSED,
     kbRightShift  = SHIFT_PRESSED,
@@ -148,8 +148,9 @@ const ushort
     kbCapsState   = CAPSLOCK_ON,
     kbEnhanced    = ENHANCED_KEY,
     kbInsState    = 0x200,  // Ensure this doesn't overlap above values
-    kbPaste       = 0x400;
+    kbPaste       = 0x400
 #endif
+};
 
 #endif // __TKeys
 

--- a/include/tvision/ttext.h
+++ b/include/tvision/ttext.h
@@ -10,9 +10,9 @@
 #define __TText
 
 #if !defined( __BORLANDC__ )
-const int maxCharLength = 4; // Maximum length of a UTF-8 codepoint.
+enum : int { maxCharLength = 4 }; // Maximum length of a UTF-8 codepoint.
 #else
-const int maxCharLength = 1; // All characters are single-byte-encoded.
+enum : int { maxCharLength = 1 }; // All characters are single-byte-encoded.
 #endif
 
 struct TTextMetrics

--- a/include/tvision/ttypes.h
+++ b/include/tvision/ttypes.h
@@ -66,7 +66,7 @@ struct TColorAttr;
 struct TAttrPair;
 #endif
 
-const char EOS = '\0';
+enum : char { EOS = '\0'};
 
 enum StreamableInit { streamableInit };
 
@@ -115,7 +115,7 @@ typedef int ccIndex;
 typedef Boolean (*ccTestFunc)( void *, void * );
 typedef void (*ccAppFunc)( void *, void * );
 
-const int ccNotFound = -1;
+enum : int { ccNotFound = -1};
 
 extern const uchar specialChars[];
 

--- a/include/tvision/validate.h
+++ b/include/tvision/validate.h
@@ -19,7 +19,7 @@
 
 // TValidator Status constants
 
-static const int
+enum : int {
   vsOk     =  0,
   vsSyntax =  1,      // Error in the syntax of either a TPXPictureValidator
                       // or a TDBPictureValidator
@@ -27,7 +27,8 @@ static const int
 // Validator option flags
   voFill     =  0x0001,
   voTransfer =  0x0002,
-  voReserved =  0x00FC;
+  voReserved =  0x00FC
+};
 
 // TVTransfer constants
 

--- a/include/tvision/views.h
+++ b/include/tvision/views.h
@@ -24,7 +24,7 @@
 #if !defined( __COMMAND_CODES )
 #define __COMMAND_CODES
 
-const ushort
+enum : ushort {
 
 //  Standard command codes
 
@@ -197,7 +197,8 @@ const ushort
 //  Event masks
 
     positionalEvents    = evMouse & ~evMouseWheel,
-    focusedEvents       = evKeyboard | evCommand;
+    focusedEvents       = evKeyboard | evCommand
+};
 
 #endif  // __COMMAND_CODES
 


### PR DESCRIPTION
Convert variable definitions in *.h files into enums to avoid duplicated symbols in resulting binaries.

This reduces the sizes of resulting binaries by almost 30%:
![image](https://github.com/magiblot/tvision/assets/35846529/66cc0684-a293-4341-9abe-1e51390c189f)