### PR TITLE
Support Big Endian Linux platform (z/Linux)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,17 @@ endif()
 
 option(TV_BUILD_TESTS "Build and run tests" OFF)
 
+# Endianness detection
+
+include(TestBigEndian)
+TEST_BIG_ENDIAN(BIGENDIAN)
+if(${BIGENDIAN})
+    add_definitions(-DTV_BIG_ENDIAN)
+    tv_message_mp(STATUS "BIG ENDIAN platform detected")
+else()
+    tv_message_mp(STATUS "LITTLE ENDIAN platform detected")
+endif(${BIGENDIAN})
+
 # Library
 
 add_subdirectory(source)

--- a/include/tvision/internal/ansidisp.h
+++ b/include/tvision/internal/ansidisp.h
@@ -30,14 +30,14 @@ struct TermColor
 
     TermColor& operator=(uint32_t val) noexcept
     {
-        memcpy(this, &val, sizeof(*this));
+        tvintmemcpy(this, &val, sizeof(*this));
         return *this;
         static_assert(sizeof(*this) == 4, "");
     }
     operator uint32_t() const noexcept
     {
         uint32_t val;
-        memcpy(&val, this, sizeof(*this));
+        tvintmemcpy(&val, this, sizeof(*this));
         return val;
     }
     TermColor(uint8_t aIdx, TermColorTypes aType) noexcept

--- a/include/tvision/internal/codepage.h
+++ b/include/tvision/internal/codepage.h
@@ -23,7 +23,7 @@ public:
     static uint32_t toPackedUtf8(unsigned char c) noexcept
     {
         uint32_t asInt;
-        memcpy(&asInt, (*currentToUtf8)[c], sizeof(asInt));
+        tvintmemcpy(&asInt, (*currentToUtf8)[c], sizeof(asInt));
         return asInt;
     }
 

--- a/include/tvision/internal/strings.h
+++ b/include/tvision/internal/strings.h
@@ -13,8 +13,12 @@ inline constexpr Int string_as_int(TStringView s) noexcept
 {
     Int res = 0;
     for (size_t i = 0; i < min(s.size(), sizeof(res)); ++i)
+#ifndef TV_BIG_ENDIAN
         // CAUTION: Assumes Little Endian.
         res |= uint64_t(uint8_t(s[i])) << 8*i;
+#else
+        res |= uint64_t(uint8_t(s[i])) << 8*(sizeof(res)-1-i);
+#endif
     return res;
 }
 
@@ -35,6 +39,7 @@ inline char *fast_btoa(uint8_t value, char *buffer) noexcept
 {
     extern const btoa_lut_t btoa_lut;
     const auto &lut = (btoa_lut_elem_t (&) [256]) btoa_lut;
+#ifndef TV_BIG_ENDIAN
     // CAUTION: Assumes Little Endian.
     // We can afford to write more bytes into 'buffer' than digits.
     uint32_t asInt;
@@ -42,6 +47,11 @@ inline char *fast_btoa(uint8_t value, char *buffer) noexcept
     memcpy(buffer, &asInt, 4);
     return buffer + (asInt >> 24);
     static_assert(sizeof(btoa_lut_elem_t) == 4, "");
+#else
+    memcpy(buffer, &lut[value].chars, lut[value].digits);
+    buffer[lut[value].digits] = 0;  // null-terminate for safety - may not be needed?
+    return buffer + lut[value].digits;
+#endif
 }
 
 } // namespace tvision

--- a/include/tvision/internal/utf8.h
+++ b/include/tvision/internal/utf8.h
@@ -66,7 +66,7 @@ inline size_t utf32To8(uint32_t u32, char u8[4]) noexcept
             (( u32        & 0b00111111) | 0b10000000) << 24;
         length = 4;
     }
-    memcpy(u8, &asInt, 4);
+    tvintmemcpy(u8, &asInt, 4);
     return length;
 }
 

--- a/include/tvision/scrncell.h
+++ b/include/tvision/scrncell.h
@@ -83,7 +83,7 @@ inline void TCellChar::moveInt(uint32_t mbc, bool wide)
 {
     memset(this, 0, sizeof(*this));
     // CAUTION: Assumes Little Endian.
-    memcpy(_text, &mbc, sizeof(mbc));
+    tvintmemcpy(_text, &mbc, sizeof(mbc));
     _flags = -int(wide) & fWide;
 }
 

--- a/include/tvision/system.h
+++ b/include/tvision/system.h
@@ -187,8 +187,14 @@ inline void TMouse::registerHandler( unsigned mask, void (_FAR *func)() )
 
 struct CharScanType
 {
+#ifndef TV_BIG_ENDIAN
     uchar charCode;
     uchar scanCode;
+#else
+    // big endian version reverses the order
+    uchar scanCode;
+    uchar charCode;
+#endif
 };
 
 struct KeyDownEvent

--- a/include/tvision/util.h
+++ b/include/tvision/util.h
@@ -110,4 +110,21 @@ char *ultoa( ulong value, char *buffer, int radix ) noexcept;
 
 #endif // __BORLANDC__
 
+#ifdef TV_BIG_ENDIAN
+    inline void *be_tvintmemcpy(void *dest, const void *src, size_t n)  // implementation of tvintmemcpy for Big Endian platforms, reverses bytes while copying
+    {
+        // TVision assumes Little Endian byte order for some operations where uints are assigned to stucts etc.
+        // This memcpy-like function reverses the order of the bytes when copying them, so can be used on big-endian
+        // platforms in place of a standard memcpy.
+        for (size_t i=0; i<n; i++) {
+            ((uchar*)dest)[i] = ((const uchar*)src)[n-i-1];
+        }
+        return dest;
+    }
+    #define tvintmemcpy be_tvintmemcpy
+#else
+    // On little-endian platforms, just use memcpy as before
+    #define tvintmemcpy memcpy
+#endif
+
 #endif  // __UTIL_H

--- a/source/platform/ansidisp.cpp
+++ b/source/platform/ansidisp.cpp
@@ -159,7 +159,7 @@ struct alignas(8) colorconv_r
     colorconv_r(TermColor aColor, TColorAttr::Style aExtraFlags=0) noexcept
     {
         uint64_t val = aColor | (uint64_t(aExtraFlags) << 32);
-        memcpy(this, &val, 8);
+        tvintmemcpy(this, &val, 8);
         static_assert(sizeof(*this) == 8, "");
     }
 };


### PR DESCRIPTION
The fixes are broadly in 3 areas:
  o  use of memcpy to copy between char* and integer* types. In my PR, I created a 'tvintmemcpy', which #defines to the normal memcpy on LE platforms (so no runtime changes), but does a crude byte-reversed memcpy on BE ones. I then went through and changed any memcpy calls where one param is an integer pointer and the other is a char* to use this new tvintmemcpy. This issue affects TermColor::operator= and TermColor::operator uint32_t, CpTranslator::toPackedUtf8, utf32To8, TCellChar::moveInt, and the struct colorconv_r::colorconv_r(TermColor aColor...) constructor. string_as_int has a similar issue, but I've had to address it slightly differently. I've noticed that platform/far2l.cpp seems to have 12 memcpy calls which look like they would need to also be replaced by tvintmemcpy, but I'm unable to test this so haven't made these changes.

  o  the optimisation of fast_btoa, as the comment says, is only suitable for LE platforms as the btoa_lut_elem_t is a compound struct (3 chars and a uint8). In my PR, I've provided a non-optimised version under the BE #define, which also (probably unnecessarily) null-terminates the destination buffer.

  o  The struct KeyDownEvent relies on a union of ushort and CharScanType types, but the order of the elements of the CharScanType are reversed on BE platforms. To minimise the diff, I've just reversed the order of the charCode and scanCode members of the struct CharScanType under the TV_BIG_ENDIAN define.