### PR TITLE
Makes TChDirDialog on Linux handle native Linux paths (and fix crash)

### DIFF
--- a/source/tvision/tchdrdlg.cpp
+++ b/source/tvision/tchdrdlg.cpp
@@ -88,7 +88,11 @@ void TChDirDialog::getData( void * )
 {
 }
 
-#define isSeparator(c) (c == '\\' || c == '/')
+#ifndef _TV_UNIX
+  #define isSeparator(c) (c == '\\' || c == '/')
+#else
+  #define isSeparator(c) (c == '/')
+#endif
 
 static void trimEndSeparator(char *path)
 {
@@ -114,6 +118,7 @@ void TChDirDialog::handleEvent( TEvent& event )
                     {
                     TDirEntry *p = dirList->list()->at( dirList->focused );
                     strcpy( curDir, p->dir() );
+#ifndef _TV_UNIX
                     if( strcmp( curDir, drivesText ) == 0 )
                         break;
                     else if( driveValid( curDir[0] ) )
@@ -124,6 +129,16 @@ void TChDirDialog::handleEvent( TEvent& event )
                         }
                     else
                         return;
+#else
+                    if ( strcmp( curDir, "/" ) == 0 )
+                        break;
+                    else
+                        {
+                        int len = strlen( curDir );
+                        if( !isSeparator(curDir[len - 1]) )
+                            strcat(curDir, "/");
+                        }
+#endif
                     break;
                     }
                 default:
@@ -163,8 +178,10 @@ void TChDirDialog::setUpDialog()
 
 static int changeDir( const char *path )
 {
+#ifndef _TV_UNIX
     if( path[1] == ':' )
         setdisk( toupper(path[0]) - 'A' );
+#endif
     return chdir( path );
 }
 

--- a/source/tvision/tdircoll.cpp
+++ b/source/tvision/tdircoll.cpp
@@ -76,7 +76,11 @@ Boolean isDir( const char *str ) noexcept
                     (ff.ff_attrib & FA_DIREC) != 0 );
 }
 
-#define isSeparator(c) (c == '\\' || c == '/')
+#ifndef _TV_UNIX
+  #define isSeparator(c) (c == '\\' || c == '/')
+#else
+  #define isSeparator(c) (c == '/')
+#endif
 
 Boolean pathValid( const char *path ) noexcept
 {
@@ -124,6 +128,7 @@ Boolean validFileName( const char *fileName ) noexcept
 
 void getCurDir( char *dir, char drive ) noexcept
 {
+#ifndef _TV_UNIX
     dir[0] = (char) ((0 <= drive && drive <= 'Z' - 'A' ? drive : getdisk()) + 'A');
     dir[1] = ':';
     dir[2] = '\\';
@@ -131,6 +136,10 @@ void getCurDir( char *dir, char drive ) noexcept
     getcurdir( dir[0] - 'A' + 1, dir+3 );
     if( strlen( dir ) > 3 )
         strnzcat( dir, "\\", MAXPATH );
+#else
+    getcwd( dir, MAXPATH );
+    strnzcat( dir, "/", MAXPATH );
+#endif
 }
 
 Boolean isWild( const char *f ) noexcept


### PR DESCRIPTION
Hi magliblot,

For the record, here are the hacky changes I made to get the TChDirDialog to work on Linux with native paths (and not crash when doing so).  For my use, I don't need/want the Linux TChDirDialog to handle Windows paths, so it doesn't (eg it should accept names with the valid-on-Linux '\\' char in it without assuming that's a directory separator).  Because I don't need to support Windows paths on Linux, it's also switched based on the existing _TV_UNIX #define, rather than some runtime flag.

The fix for the crash is the "if ( end == NULL )" check in source/tvision/tdirlist.cpp.

As discussed, there could well be other places where the 'Windows paths on Linux' is still assumed - I've just done what I needed to get the TChDirDialog up and running as I wanted it.

Hope this helps you do it properly if you get chance to look at it at some point.
Mark