### PR TITLE
Switch to GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,8 @@ option(TV_OPTIMIZE_BUILD "Use CMake's Precompiled Headers" ON)
 
 option(TV_BUILD_AVSCOLOR "Build AviSynth TermColor plugin" OFF)
 
+include(GNUInstallDirs)
+
 tv_message_mp(STATUS "Install path: ${CMAKE_INSTALL_PREFIX}")
 tv_message(STATUS "Build Examples: ${TV_BUILD_EXAMPLES}")
 if (MAY_BUILD_USING_GPM)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -25,7 +25,7 @@ if (TV_BUILD_EXAMPLES)
         # Until CMake 3.13, 'install' only accepts targets defined
         # in the current directory. So install from this function.
         if (${app} IN_LIST TVINSTALLAPPS)
-            install(TARGETS ${app} RUNTIME DESTINATION bin)
+            install(TARGETS ${app} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
         endif()
     endfunction()
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -153,14 +153,14 @@ tv_set_output_dir(${PROJECT_NAME})
 #
 install(TARGETS ${PROJECT_NAME}
     EXPORT ${PROJECT_NAME}-config
-    ARCHIVE DESTINATION lib
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     COMPONENT library
 )
 
 # package configuration
 
 install(EXPORT ${PROJECT_NAME}-config
-    DESTINATION lib/cmake/${PROJECT_NAME}
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
     NAMESPACE ${PROJECT_NAME}::
     FILE ${PROJECT_NAME}-config.cmake
     COMPONENT library
@@ -169,7 +169,7 @@ install(EXPORT ${PROJECT_NAME}-config
 # includes
 # ./include/tvision and children copied to destination/include/tvision etc...
 #
-install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/tvision" DESTINATION include)
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/tvision" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # Build optimization
 


### PR DESCRIPTION
This PR changes the CMake files to import and use standard [GNUInstallDirs](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html). Resolves https://github.com/magiblot/tvision/issues/162.