### PR TITLE
Modernize Open File dialog

### DIFF
--- a/include/tvision/stddlg.h
+++ b/include/tvision/stddlg.h
@@ -276,6 +276,9 @@ public:
     virtual void getData( void *rec );
     virtual void setData( void *rec );
 
+    virtual void draw();
+    virtual TPalette& getPalette() const;
+
     TFileCollection *list();
 
 private:

--- a/source/tvision/tfilecol.cpp
+++ b/source/tvision/tfilecol.cpp
@@ -43,14 +43,14 @@ int TFileCollection::compare(void *key1, void *key2)
         return 0;
 
     if( strcmp( getName( key1 ), ".." ) == 0 )
-        return 1;
-    if( strcmp( getName( key2 ), ".." ) == 0 )
         return -1;
+    if( strcmp( getName( key2 ), ".." ) == 0 )
+        return 1;
 
     if( (attr( key1 ) & FA_DIREC) != 0 && (attr( key2 ) & FA_DIREC) == 0 )
-        return 1;
-    if( (attr( key2 ) & FA_DIREC) != 0 && (attr( key1 ) & FA_DIREC) == 0 )
         return -1;
+    if( (attr( key2 ) & FA_DIREC) != 0 && (attr( key1 ) & FA_DIREC) == 0 )
+        return 1;
 
     return strcmp( getName( key1 ), getName( key2 ) );
 }

--- a/source/tvision/tlstview.cpp
+++ b/source/tvision/tlstview.cpp
@@ -313,16 +313,16 @@ void TListViewer::handleEvent( TEvent& event )
                     newItem = focused - size.y * numCols;
                     break;
                 case kbHome:
-                    newItem = topItem;
+                    newItem = 0;
                     break;
                 case kbEnd:
-                    newItem = topItem + (size.y * numCols) - 1;
-                    break;
-                case kbCtrlPgDn:
                     newItem = range - 1;
                     break;
+                case kbCtrlPgDn:
+                    newItem = topItem + (size.y * numCols) - 1;
+                    break;
                 case kbCtrlPgUp:
-                    newItem = 0;
+                    newItem = topItem;
                     break;
                 default:
                     return;


### PR DESCRIPTION
- Sort files and folders in a way orthodox file manager do: folders first, files second
- Swap File List and File Name fields (just as it is done in Windows "Open File" dialog) to save key presses on the most frequent operations
- After exiting the folder with "..", set cursor to the folder we have exited from
- Home and End keys now move cursor to the first and last file in list, not first and last visible file (just as they behave in Windows)
- Mark folders by colors, not by tailing slash. Reduces visual noise