### PR TITLE
Added the ability to specify the render buffer size in the constructor.

### DIFF
--- a/include/tvision/drawbuf.h
+++ b/include/tvision/drawbuf.h
@@ -44,7 +44,7 @@ public:
     void putChar( ushort indent, uchar c ) noexcept;
 
 #if defined( __FLAT__ )
-    TDrawBuffer() noexcept;
+    TDrawBuffer(size_t bufferSize = -1) noexcept;
     ~TDrawBuffer();
 #endif
 

--- a/include/tvision/drawbuf.h
+++ b/include/tvision/drawbuf.h
@@ -44,7 +44,7 @@ public:
     void putChar( ushort indent, uchar c ) noexcept;
 
 #if defined( __FLAT__ )
-    TDrawBuffer(size_t bufferSize = -1) noexcept;
+    TDrawBuffer(size_t bufferSize = -1);
     ~TDrawBuffer();
 #endif
 

--- a/source/tvision/drivers.cpp
+++ b/source/tvision/drivers.cpp
@@ -368,7 +368,7 @@ I   POP     DS
 }
 
 #if defined( __FLAT__ )
-TDrawBuffer::TDrawBuffer(const size_t bufferSize) noexcept
+TDrawBuffer::TDrawBuffer(const size_t bufferSize)
 {
     // Unlike on DOS, the screen's dimensions are arbitrary, so we have to take
     // this into account and allocate the buffer dynamically. We must take the

--- a/source/tvision/drivers.cpp
+++ b/source/tvision/drivers.cpp
@@ -368,14 +368,17 @@ I   POP     DS
 }
 
 #if defined( __FLAT__ )
-TDrawBuffer::TDrawBuffer() noexcept
+TDrawBuffer::TDrawBuffer(const size_t bufferSize) noexcept
 {
     // Unlike on DOS, the screen's dimensions are arbitrary, so we have to take
     // this into account and allocate the buffer dynamically. We must take the
     // largest of the screen's dimensions, since TDrawBuffer can also be used to
     // draw vertical views (e.g. TScrollBar).
     // In addition, we give some room for views that might exceed the screen size.
-    capacity = 8 + max(max(TScreen::screenWidth, TScreen::screenHeight), 80);
+    if (bufferSize == -1)
+        capacity = 8 + max(max(TScreen::screenWidth, TScreen::screenHeight), 80);
+    else
+        capacity = bufferSize;
     data = new TScreenCell[capacity];
 #if !defined( __BORLANDC__ )
     // We cannot leave the buffer uninitialized because, if it ends up being


### PR DESCRIPTION
Added the ability to specify the render buffer size in the constructor. This can be used to render the entire control to the buffer and then call the `writeBuf` method once, instead of multiple `writeLine` calls.

Backward compatibility is preserved by using the default value (-1).