### PR TITLE
Add table list box

### DIFF
--- a/include/tvision/dialogs.h
+++ b/include/tvision/dialogs.h
@@ -715,6 +715,60 @@ inline TCollection *TListBox::list()
 
 #endif  // Uses_TListBox
 
+/* ---------------------------------------------------------------------- */
+/*      class TTableListBox                                               */
+/*                                                                        */
+/*      Displays a one-dimensional selection list as rows made of          */
+/*      multiple text columns. Unlike TListBox's numCols layout, each      */
+/*      row remains one selectable item.                                   */
+/* ---------------------------------------------------------------------- */
+
+#if defined( Uses_TTableListBox ) && !defined( __TTableListBox )
+#define __TTableListBox
+
+class _FAR TRect;
+class _FAR TScrollBar;
+
+struct TTableListBoxRec
+{
+    const char * const *cells;
+    ushort rowCount;
+    ushort columnCount;
+    ushort selection;
+};
+
+class TTableListBox : public TListViewer
+{
+
+public:
+
+    TTableListBox( const TRect& bounds, TScrollBar *aScrollBar ) noexcept;
+    ~TTableListBox();
+
+    virtual ushort dataSize();
+    virtual void getData( void *rec );
+    virtual void getText( char *dest, short item, short maxLen );
+    virtual void setData( void *rec );
+    void setRows( const char * const *aCells, ushort aRowCount,
+                  ushort aColumnCount, ushort selection = 0 );
+    short selectedIndex() const noexcept;
+
+    ushort columnPadding;
+
+protected:
+
+    virtual TStringView getCell( short row, short column ) const noexcept;
+    void updateColumnWidths();
+
+    const char * const *cells;
+    ushort rowCount;
+    ushort columnCount;
+    ushort *columnWidths;
+
+};
+
+#endif  // Uses_TTableListBox
+
 
 /* ---------------------------------------------------------------------- */
 /*      class TStaticText                                                 */

--- a/include/tvision/tv.h
+++ b/include/tvision/tv.h
@@ -365,6 +365,11 @@
 #define __INC_DIALOGS_H
 #endif
 
+#if defined( Uses_TTableListBox )
+#define Uses_TListViewer
+#define __INC_DIALOGS_H
+#endif
+
 #if defined( Uses_TCheckBoxes )
 #define Uses_TCluster
 #define __INC_DIALOGS_H

--- a/source/tvision/ttablist.cpp
+++ b/source/tvision/ttablist.cpp
@@ -1,0 +1,152 @@
+/*------------------------------------------------------------*/
+/* filename -       ttablist.cpp                             */
+/*                                                            */
+/* function(s)                                                */
+/*                  TTableListBox member functions            */
+/*------------------------------------------------------------*/
+
+#define Uses_TTableListBox
+#define Uses_TEvent
+#define Uses_TText
+#include <tvision/tv.h>
+
+#if !defined( __STRING_H )
+#include <string.h>
+#endif  // __STRING_H
+
+namespace {
+
+void appendText(char *dest, short maxLen, TStringView text) noexcept
+{
+    size_t len = strlen(dest);
+    size_t space = len < (size_t) maxLen ? (size_t) maxLen - len : 0;
+    size_t count = text.size() < space ? text.size() : space;
+
+    if( count > 0 )
+        {
+        memcpy(dest + len, text.begin(), count);
+        dest[len + count] = EOS;
+        }
+}
+
+void appendSpaces(char *dest, short maxLen, ushort count) noexcept
+{
+    size_t len = strlen(dest);
+
+    while( count > 0 && len < (size_t) maxLen )
+        {
+        dest[len++] = ' ';
+        dest[len] = EOS;
+        --count;
+        }
+}
+
+} // namespace
+
+TTableListBox::TTableListBox( const TRect& bounds,
+                              TScrollBar *aScrollBar ) noexcept :
+    TListViewer(bounds, 1, 0, aScrollBar),
+    columnPadding( 2 ),
+    cells( 0 ),
+    rowCount( 0 ),
+    columnCount( 0 ),
+    columnWidths( 0 )
+{
+    setRange(0);
+}
+
+TTableListBox::~TTableListBox()
+{
+    delete[] columnWidths;
+}
+
+ushort TTableListBox::dataSize()
+{
+    return sizeof(TTableListBoxRec);
+}
+
+void TTableListBox::getData( void *rec )
+{
+    TTableListBoxRec *p = (TTableListBoxRec *)rec;
+
+    p->cells = cells;
+    p->rowCount = rowCount;
+    p->columnCount = columnCount;
+    p->selection = focused;
+}
+
+void TTableListBox::getText( char *dest, short item, short maxLen )
+{
+    *dest = EOS;
+    if( item < 0 || item >= (short) rowCount || columnCount == 0 )
+        return;
+    for( ushort column = 0; column < columnCount; ++column )
+        {
+        TStringView cell = getCell(item, column);
+        ushort cellWidth = (ushort) strwidth(cell);
+
+        appendText(dest, maxLen, cell);
+        if( column + 1 < columnCount )
+            {
+            if( columnWidths != 0 && columnWidths[column] > cellWidth )
+                appendSpaces(dest, maxLen, columnWidths[column] - cellWidth);
+            appendSpaces(dest, maxLen, columnPadding);
+            }
+        }
+}
+
+void TTableListBox::setData( void *rec )
+{
+    TTableListBoxRec *p = (TTableListBoxRec *)rec;
+
+    setRows(p->cells, p->rowCount, p->columnCount, p->selection);
+}
+
+void TTableListBox::setRows( const char * const *aCells, ushort aRowCount,
+                             ushort aColumnCount, ushort selection )
+{
+    cells = aCells;
+    rowCount = aRowCount;
+    columnCount = aColumnCount;
+    updateColumnWidths();
+    setRange(rowCount);
+    if( rowCount == 0 )
+        selection = 0;
+    else if( selection >= rowCount )
+        selection = rowCount - 1;
+    focusItem(selection);
+    drawView();
+}
+
+short TTableListBox::selectedIndex() const noexcept
+{
+    return rowCount > 0 ? focused : -1;
+}
+
+TStringView TTableListBox::getCell( short row, short column ) const noexcept
+{
+    const char *cell = 0;
+
+    if( cells != 0 && row >= 0 && row < (short) rowCount &&
+        column >= 0 && column < (short) columnCount )
+        cell = cells[(size_t) row * columnCount + column];
+    return cell != 0 ? TStringView(cell) : TStringView();
+}
+
+void TTableListBox::updateColumnWidths()
+{
+    delete[] columnWidths;
+    columnWidths = 0;
+    if( columnCount == 0 )
+        return;
+    columnWidths = new ushort[columnCount];
+    for( ushort column = 0; column < columnCount; ++column )
+        columnWidths[column] = 0;
+    for( ushort row = 0; row < rowCount; ++row )
+        for( ushort column = 0; column < columnCount; ++column )
+            {
+            ushort width = (ushort) strwidth(getCell(row, column));
+            if( width > columnWidths[column] )
+                columnWidths[column] = width;
+            }
+}


### PR DESCRIPTION
## Summary

Adds `TTableListBox`, a `TListViewer`-based control for displaying a one-dimensional selection list as rows with multiple text columns. This differs from `TListBox`'s existing `numCols` layout, where items are distributed across screen columns; here each table row remains one selectable item.

The control accepts a flat `const char*` cell matrix plus row/column counts, computes display widths per column, and renders padded row text through the existing list-view drawing path. It does not own the cell strings and does not change existing `TListBox` behavior.

## Validation

- `cmake -S . -B build -DTV_BUILD_EXAMPLES=ON -DTV_BUILD_TESTS=ON`
- `cmake --build build -j2`
- header compile smoke test for `Uses_TTableListBox`
- `git -c core.whitespace=cr-at-eol diff --cached --check` before commit

## Notes

This is intended for report/table-like lists such as command/key binding views, diagnostics, or profile lists where a single selectable row has multiple visible fields.