### PR TITLE
Test macOS builds with GoogleTest and document setup

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -231,9 +231,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install Dependencies
+      run: brew install googletest
+
     - name: Configure CMake
       shell: bash
-      run: cmake . -DCMAKE_BUILD_TYPE=Release
+      run: cmake . -DCMAKE_BUILD_TYPE=Release -DTV_BUILD_TESTS=ON
 
     - name: Build
       shell: bash

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The original location of this project is https://github.com/magiblot/tvision.
 * [Releases and downloads](#downloads)
 * Build environment
     * [Linux](#build-linux)
+    * [macOS](#build-macos)
     * [Windows (MSVC)](#build-msvc)
     * [Windows (MinGW)](#build-mingw)
     * [Windows/DOS (Borland C++)](#build-borland)
@@ -139,6 +140,36 @@ You may also need:
 `-lgpm` is only necessary if Turbo Vision was built with `libgpm` support.
 
 The backward-compatibility headers in `include/tvision/compat/borland` emulate the Borland C++ RTL. Turbo Vision's source code still depends on them, and they could be useful if porting old applications. This also means that including `tvision/tv.h` will bring several `std` names to the global namespace.
+
+<div id="build-macos"></div>
+
+### macOS
+
+Turbo Vision is built and tested on macOS with Apple Clang in GitHub Actions. Install the Xcode Command Line Tools and CMake before configuring the project:
+
+```sh
+xcode-select --install
+brew install cmake
+```
+
+The macOS SDK provides the required `ncurses` library. A release build of the library and example applications can be created with:
+
+```sh
+cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Release
+cmake --build ./build --parallel "$(sysctl -n hw.logicalcpu)"
+```
+
+The resulting library and executables are placed in `./build`. For example, run `./build/hello` or `./build/tvdemo` from a terminal. The applications can usually be closed with `Alt+X`.
+
+To build and run the optional tests, install GoogleTest and enable `TV_BUILD_TESTS` in a separate build directory:
+
+```sh
+brew install googletest
+cmake -S . -B ./build-tests -DCMAKE_BUILD_TYPE=Release -DTV_BUILD_TESTS=ON
+cmake --build ./build-tests --parallel "$(sysctl -n hw.logicalcpu)"
+```
+
+The public Turbo Vision library target continues to require C++14. Current GoogleTest releases require C++17, so only the test executable is built with C++17 when tests are enabled.
 
 <div id="build-msvc"></div>
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,7 @@ if (TV_BUILD_TESTS)
 
     add_executable(${PROJECT_NAME}-test ${TEST_SRC})
 
-    target_compile_features(${PROJECT_NAME}-test PRIVATE cxx_std_14)
+    target_compile_features(${PROJECT_NAME}-test PRIVATE cxx_std_17)
     target_include_directories(${PROJECT_NAME}-test PRIVATE "${CMAKE_CURRENT_LIST_DIR}")
 
     tv_add_private_includes(${PROJECT_NAME}-test)
@@ -13,6 +13,9 @@ if (TV_BUILD_TESTS)
     tv_message(STATUS "Found 'gtest': ${GTEST}")
     find_library(GTEST_MAIN gtest_main REQUIRED)
     tv_message(STATUS "Found 'gtest_main': ${GTEST_MAIN}")
+    find_path(GTEST_INCLUDE_DIR gtest/gtest.h REQUIRED)
+    tv_message(STATUS "Found 'gtest' headers: ${GTEST_INCLUDE_DIR}")
+    target_include_directories(${PROJECT_NAME}-test PRIVATE "${GTEST_INCLUDE_DIR}")
     target_link_libraries(${PROJECT_NAME}-test PRIVATE
         ${PROJECT_NAME}
         ${GTEST}


### PR DESCRIPTION
Hi @magiblot,

Thank you for maintaining Turbo Vision. I built the project and ran its examples successfully on an Apple Silicon Mac, then followed up on the gap between the existing macOS build job and the optional GoogleTest suite.

## What changed

- Add user-facing macOS build and test instructions to the README.
- Install GoogleTest and enable `TV_BUILD_TESTS` in the existing macOS GitHub Actions job.
- Build only the test executable with C++17, as required by GoogleTest 1.17.
- Discover the GoogleTest header directory in CMake so Homebrew installations work without manual compiler flags.

The public `tvision` target remains `cxx_std_14`; this pull request does not change the library's language baseline, public API, or ABI. I opened #226 separately to discuss whether a broader C++17 transition would be desirable in the future.

## Validation

- Release build of the library and all examples with Apple Clang 21.
- Test-enabled release build with Homebrew GoogleTest 1.17.0.
- 39 tests from 12 test suites passed.
- Confirmed that the test target compiles with `-std=gnu++17` while the public library target still declares `cxx_std_14`.
- Launched the `hello` example in a terminal and exited with `Alt+X`.
- `git diff --check` passed.

I am submitting this as a draft so you can confirm that the narrow test-only C++17 boundary and the documentation approach fit the project's compatibility goals.
