### PR TITLE
TComboBox implementation

### DIFF
--- a/include/tvision/dialogs.h
+++ b/include/tvision/dialogs.h
@@ -1218,6 +1218,7 @@ public:
     virtual TComboWindow *initComboWindow( const TRect& bounds );
 
     virtual void focusItem( short item ) noexcept;
+    virtual void setState( ushort aState, Boolean enable );
     void newList( TComboItem *aItems, short aFocused = 0 ) noexcept;
 
     short focused;

--- a/include/tvision/dialogs.h
+++ b/include/tvision/dialogs.h
@@ -1060,6 +1060,179 @@ inline opstream& operator << ( opstream& os, THistory* cl )
 
 #endif  // Uses_THistory
 
+/* ---------------------------------------------------------------------- */
+/*      class TComboItem                                                  */
+/*                                                                        */
+/*      A node in a singly-linked list of combo box entries. Each entry   */
+/*      has a displayed 'text' and an opaque 'value' that the programmer  */
+/*      may use to identify the entry (e.g. an enum or an index into      */
+/*      another array). 'value' may be left as 0 if unused.               */
+/*                                                                        */
+/*      Ownership of the whole chain is transferred to the TComboBox it   */
+/*      is passed to, which deletes it in its own destructor. A           */
+/*      TComboWindow only borrows the chain for as long as its popup is   */
+/*      on screen and does not delete it -- the same convention used by   */
+/*      THistoryWindow, which does not own the (separately managed)       */
+/*      history strings it displays either.                               */
+/* ---------------------------------------------------------------------- */
+
+#if defined( Uses_TComboItem ) && !defined( __TComboItem )
+#define __TComboItem
+
+class TComboItem
+{
+
+public:
+
+    TComboItem( TStringView aText, ulong aValue, TComboItem *aNext ) noexcept :
+        value( aValue ),
+        next( aNext )
+        { text = newStr(aText); }
+    ~TComboItem() { delete[] (char *) text; }
+
+    const char *text;
+    ulong value;
+    TComboItem *next;
+
+};
+
+#endif  // Uses_TComboItem
+
+/* ---------------------------------------------------------------------- */
+/*      class TComboViewer                                                */
+/*                                                                        */
+/*      Palette layout                                                    */
+/*        1 = Active                                                      */
+/*        2 = Inactive                                                    */
+/*        3 = Focused                                                     */
+/*        4 = Selected                                                    */
+/*        5 = Divider                                                     */
+/* ---------------------------------------------------------------------- */
+
+#if defined( Uses_TComboViewer ) && !defined( __TComboViewer )
+#define __TComboViewer
+
+class _FAR TRect;
+class _FAR TScrollBar;
+class _FAR TComboItem;
+
+class TComboViewer : public TListViewer
+{
+
+public:
+
+    TComboViewer( const TRect& bounds,
+                  TScrollBar *aVScrollBar,
+                  TComboItem *aItems,
+                  short aFocused
+                ) noexcept;
+
+    virtual TPalette& getPalette() const;
+    virtual void getText( char *dest, short item, short maxLen );
+    virtual void handleEvent( TEvent& event );
+    ulong getValue( short item ) noexcept;
+    int itemWidth() noexcept;
+
+protected:
+
+    TComboItem *items;
+
+};
+
+#endif  // Uses_TComboViewer
+
+/* ---------------------------------------------------------------------- */
+/*      class TComboWindow                                                */
+/*                                                                        */
+/*      Palette layout                                                    */
+/*        1 = Frame passive                                               */
+/*        2 = Frame active                                                */
+/*        3 = Frame icon                                                  */
+/*        4 = ScrollBar page area                                         */
+/*        5 = ScrollBar controls                                          */
+/*        6 = ComboViewer normal text                                     */
+/*        7 = ComboViewer selected text                                   */
+/* ---------------------------------------------------------------------- */
+
+#if defined( Uses_TComboWindow ) && !defined( __TComboWindow )
+#define __TComboWindow
+
+class _FAR TRect;
+class _FAR TComboItem;
+class _FAR TComboViewer;
+
+class TComboWindow : public TWindow
+{
+
+public:
+
+    TComboWindow( const TRect& bounds, TComboItem *aItems, short aFocused ) noexcept;
+
+    virtual TPalette& getPalette() const;
+    virtual short getSelection();
+    virtual void handleEvent( TEvent& event );
+
+protected:
+
+    TComboViewer *viewer;
+
+};
+
+#endif  // Uses_TComboWindow
+
+/* ---------------------------------------------------------------------- */
+/*      class TComboBox                                                   */
+/*                                                                        */
+/*      A single-line, single-selection drop-down combo box. Clicking it, */
+/*      or pressing Space/Enter/Down while it is focused, opens a         */
+/*      TComboWindow (a borderless popup list, built the same way         */
+/*      THistoryWindow is for TInputLine) from which an entry can be      */
+/*      chosen with the mouse, Enter or double-click; Esc or a click      */
+/*      outside the popup cancels it.                                     */
+/*                                                                        */
+/*      Palette layout                                                    */
+/*        1 = Normal text                                                 */
+/*        2 = Focused text                                                */
+/*        3 = Arrow                                                       */
+/* ---------------------------------------------------------------------- */
+
+#if defined( Uses_TComboBox ) && !defined( __TComboBox )
+#define __TComboBox
+
+class _FAR TRect;
+class _FAR TComboItem;
+class _FAR TComboWindow;
+struct _FAR TEvent;
+
+class TComboBox : public TView
+{
+
+public:
+
+    TComboBox( const TRect& bounds, TComboItem *aItems, short aFocused = 0 ) noexcept;
+    ~TComboBox();
+
+    virtual void draw();
+    virtual TPalette& getPalette() const;
+    virtual void handleEvent( TEvent& event );
+    virtual TComboWindow *initComboWindow( const TRect& bounds );
+
+    virtual void focusItem( short item ) noexcept;
+    void newList( TComboItem *aItems, short aFocused = 0 ) noexcept;
+
+    short focused;
+    const char *text;
+    ulong value;
+
+protected:
+
+    TComboItem *items;
+    short numItems;
+
+};
+
+#endif  // Uses_TComboBox
+
 #if defined( __BORLANDC__ )
 #pragma option -Vo.
 #endif

--- a/include/tvision/tv.h
+++ b/include/tvision/tv.h
@@ -345,6 +345,29 @@
 #define __INC_DIALOGS_H
 #endif
 
+#if defined( Uses_TComboBox )
+#define Uses_TView
+#define Uses_TComboItem
+#define __INC_DIALOGS_H
+#endif
+
+#if defined( Uses_TComboWindow )
+#define Uses_TWindow
+#define Uses_TComboViewer
+#define Uses_TComboItem
+#define __INC_DIALOGS_H
+#endif
+
+#if defined( Uses_TComboViewer )
+#define Uses_TListViewer
+#define Uses_TComboItem
+#define __INC_DIALOGS_H
+#endif
+
+#if defined( Uses_TComboItem )
+#define __INC_DIALOGS_H
+#endif
+
 #if defined( Uses_TLabel )
 #define Uses_TStaticText
 #define __INC_DIALOGS_H

--- a/include/tvision/views.h
+++ b/include/tvision/views.h
@@ -194,6 +194,10 @@ const ushort
 
     cmScreenChanged     = 57,
 
+//  TComboBox messages
+
+    cmComboBoxSelectionChanged = 59,
+
 //  Event masks
 
     positionalEvents    = evMouse & ~evMouseWheel,

--- a/source/tvision/tcmbovie.cpp
+++ b/source/tvision/tcmbovie.cpp
@@ -1,0 +1,140 @@
+/*------------------------------------------------------------*/
+/* filename -       tcmbovie.cpp                              */
+/*                                                            */
+/* function(s)                                                */
+/*                  TComboViewer member functions              */
+/*------------------------------------------------------------*/
+/*
+ *      Turbo Vision - Version 2.0
+ *
+ *      Copyright (c) 1994 by Borland International
+ *      All Rights Reserved.
+ *
+ */
+
+#define Uses_TKeys
+#define Uses_TComboViewer
+#define Uses_TComboItem
+#define Uses_TScrollBar
+#define Uses_TEvent
+#include <tvision/tv.h>
+
+#if !defined( __STRING_H )
+#include <string.h>
+#endif  // __STRING_H
+
+#if !defined( __CTYPE_H )
+#include <ctype.h>
+#endif  // __CTYPE_H
+
+#define cpComboViewer "\x06\x06\x07\x06\x06"
+
+static TComboItem *nthItem( TComboItem *items, short n ) noexcept
+{
+    while( items != 0 && n > 0 )
+        {
+        items = items->next;
+        n--;
+        }
+    return items;
+}
+
+TComboViewer::TComboViewer( const TRect& bounds,
+                            TScrollBar *aVScrollBar,
+                            TComboItem *aItems,
+                            short aFocused ) noexcept :
+    TListViewer( bounds, 1, 0, aVScrollBar ),
+    items( aItems )
+{
+    short count = 0;
+    TComboItem *p;
+    for( p = items; p != 0; p = p->next )
+        count++;
+    setRange( count );
+    if( range > 0 )
+        focusItem( aFocused < range ? aFocused : short(range - 1) );
+}
+
+TPalette& TComboViewer::getPalette() const
+{
+    static TPalette palette( cpComboViewer, sizeof( cpComboViewer )-1 );
+    return palette;
+}
+
+void TComboViewer::getText( char *dest, short item, short maxChars )
+{
+    TComboItem *p = nthItem( items, item );
+    if( p != 0 )
+        {
+        strncpy( dest, p->text, maxChars );
+        dest[maxChars] = EOS;
+        }
+    else
+        *dest = EOS;
+}
+
+ulong TComboViewer::getValue( short item ) noexcept
+{
+    TComboItem *p = nthItem( items, item );
+    return p != 0 ? p->value : 0;
+}
+
+void TComboViewer::handleEvent( TEvent& event )
+{
+    if( ( event.what == evMouseDown && (event.mouse.eventFlags & meDoubleClick) ) ||
+        ( event.what == evKeyDown && event.keyDown.keyCode == kbEnter )
+      )
+        {
+        endModal( cmOK );
+        clearEvent( event );
+        }
+    else
+        if( ( event.what == evKeyDown && event.keyDown.keyCode == kbEsc ) ||
+            ( event.what == evCommand && event.message.command == cmCancel )
+          )
+            {
+            endModal( cmCancel );
+            clearEvent( event );
+            }
+        else if( event.what == evKeyDown && event.keyDown.charScan.charCode != ' ' &&
+                 event.keyDown.charScan.charCode != '\0' )
+            {
+            // Incremental search: jump to the next entry whose text starts
+            // with the typed character (case-insensitive), wrapping around.
+            char typed = event.keyDown.charScan.charCode;
+            if( range > 0 )
+                {
+                char buf[256];
+                short i;
+                for( i = 1; i <= range; i++ )
+                    {
+                    short candidate = (focused + i) % range;
+                    getText( buf, candidate, 255 );
+                    if( buf[0] != EOS && toupper((uchar)buf[0]) == toupper((uchar)typed) )
+                        {
+                        focusItemNum( candidate );
+                        drawView();
+                        break;
+                        }
+                    }
+                }
+            clearEvent( event );
+            }
+        else
+            TListViewer::handleEvent( event );
+}
+
+int TComboViewer::itemWidth() noexcept
+{
+    int width = 0;
+    char buf[256];
+    short i;
+    for( i = 0; i < range; i++ )
+        {
+        getText( buf, i, 255 );
+        int w = strwidth( buf );
+        if( w > width )
+            width = w;
+        }
+    return width;
+}

--- a/source/tvision/tcmbovie.cpp
+++ b/source/tvision/tcmbovie.cpp
@@ -81,47 +81,57 @@ ulong TComboViewer::getValue( short item ) noexcept
 
 void TComboViewer::handleEvent( TEvent& event )
 {
-    if( ( event.what == evMouseDown && (event.mouse.eventFlags & meDoubleClick) ) ||
-        ( event.what == evKeyDown && event.keyDown.keyCode == kbEnter )
-      )
+    if( event.what == evKeyDown && event.keyDown.keyCode == kbEnter )
         {
         endModal( cmOK );
         clearEvent( event );
         }
-    else
-        if( ( event.what == evKeyDown && event.keyDown.keyCode == kbEsc ) ||
-            ( event.what == evCommand && event.message.command == cmCancel )
-          )
+    else if( ( event.what == evKeyDown && event.keyDown.keyCode == kbEsc ) ||
+             ( event.what == evCommand && event.message.command == cmCancel )
+           )
+        {
+        endModal( cmCancel );
+        clearEvent( event );
+        }
+    else if( event.what == evMouseDown )
+        {
+        // A single click on an entry both picks it and closes the popup -
+        // the same behavior as a native combo box's drop-down list.
+        // Mouse events only reach here when they land inside this view
+        // (the scrollbar is a separate sibling view with its own
+        // handling), so there is no "click outside" case to guard here -
+        // TComboWindow::handleEvent already closes the popup with
+        // cmCancel for clicks outside it.
+        TListViewer::handleEvent( event ); // updates focused to the clicked row
+        endModal( cmOK );
+        clearEvent( event );
+        }
+    else if( event.what == evKeyDown && event.keyDown.charScan.charCode != ' ' &&
+             event.keyDown.charScan.charCode != '\0' )
+        {
+        // Incremental search: jump to the next entry whose text starts
+        // with the typed character (case-insensitive), wrapping around.
+        char typed = event.keyDown.charScan.charCode;
+        if( range > 0 )
             {
-            endModal( cmCancel );
-            clearEvent( event );
-            }
-        else if( event.what == evKeyDown && event.keyDown.charScan.charCode != ' ' &&
-                 event.keyDown.charScan.charCode != '\0' )
-            {
-            // Incremental search: jump to the next entry whose text starts
-            // with the typed character (case-insensitive), wrapping around.
-            char typed = event.keyDown.charScan.charCode;
-            if( range > 0 )
+            char buf[256];
+            short i;
+            for( i = 1; i <= range; i++ )
                 {
-                char buf[256];
-                short i;
-                for( i = 1; i <= range; i++ )
+                short candidate = (focused + i) % range;
+                getText( buf, candidate, 255 );
+                if( buf[0] != EOS && toupper((uchar)buf[0]) == toupper((uchar)typed) )
                     {
-                    short candidate = (focused + i) % range;
-                    getText( buf, candidate, 255 );
-                    if( buf[0] != EOS && toupper((uchar)buf[0]) == toupper((uchar)typed) )
-                        {
-                        focusItemNum( candidate );
-                        drawView();
-                        break;
-                        }
+                    focusItemNum( candidate );
+                    drawView();
+                    break;
                     }
                 }
-            clearEvent( event );
             }
-        else
-            TListViewer::handleEvent( event );
+        clearEvent( event );
+        }
+    else
+        TListViewer::handleEvent( event );
 }
 
 int TComboViewer::itemWidth() noexcept

--- a/source/tvision/tcmbowin.cpp
+++ b/source/tvision/tcmbowin.cpp
@@ -1,0 +1,58 @@
+/*------------------------------------------------------------*/
+/* filename -       tcmbowin.cpp                              */
+/*                                                            */
+/* function(s)                                                */
+/*                  TComboWindow member functions              */
+/*------------------------------------------------------------*/
+/*
+ *      Turbo Vision - Version 2.0
+ *
+ *      Copyright (c) 1994 by Borland International
+ *      All Rights Reserved.
+ *
+ */
+
+#define Uses_TComboWindow
+#define Uses_TComboViewer
+#define Uses_TComboItem
+#define Uses_TScrollBar
+#define Uses_TEvent
+#include <tvision/tv.h>
+
+#define cpComboWindow "\x13\x13\x15\x18\x17\x13\x14"
+
+TComboWindow::TComboWindow( const TRect& bounds,
+                            TComboItem *aItems,
+                            short aFocused ) noexcept :
+    TWindowInit( &TComboWindow::initFrame ),
+    TWindow( bounds, 0, wnNoNumber )
+{
+    flags = wfClose;
+    TRect r = getExtent();
+    r.grow( -1, -1 );
+    viewer = new TComboViewer( r,
+        standardScrollBar( sbVertical | sbHandleKeyboard ),
+        aItems, aFocused );
+    insert( viewer );
+}
+
+TPalette& TComboWindow::getPalette() const
+{
+    static TPalette palette( cpComboWindow, sizeof( cpComboWindow )-1 );
+    return palette;
+}
+
+short TComboWindow::getSelection()
+{
+    return viewer->focused;
+}
+
+void TComboWindow::handleEvent( TEvent& event )
+{
+    TWindow::handleEvent( event );
+    if( event.what == evMouseDown && !mouseInView( event.mouse.where ) )
+        {
+        endModal( cmCancel );
+        clearEvent( event );
+        }
+}

--- a/source/tvision/tcombobo.cpp
+++ b/source/tvision/tcombobo.cpp
@@ -140,6 +140,17 @@ TComboWindow *TComboBox::initComboWindow( const TRect& bounds )
     return new TComboWindow( bounds, items, focused );
 }
 
+void TComboBox::setState( ushort aState, Boolean enable )
+{
+    TView::setState( aState, enable );
+    // TView::setState() does not repaint on sfFocused/sfSelected changes
+    // by itself (same reason TCluster and TButton override this too) -
+    // without this, the box would keep showing whichever color it was
+    // last drawn with even after focus moves elsewhere.
+    if( aState & (sfSelected | sfFocused) )
+        drawView();
+}
+
 void TComboBox::handleEvent( TEvent& event )
 {
     TView::handleEvent( event );

--- a/source/tvision/tcombobo.cpp
+++ b/source/tvision/tcombobo.cpp
@@ -1,0 +1,181 @@
+/*------------------------------------------------------------*/
+/* filename -       tcombobo.cpp                              */
+/*                                                            */
+/* function(s)                                                */
+/*                  TComboBox member functions                 */
+/*------------------------------------------------------------*/
+/*
+ *      Turbo Vision - Version 2.0
+ *
+ *      Copyright (c) 1994 by Borland International
+ *      All Rights Reserved.
+ *
+ */
+
+#define Uses_TKeys
+#define Uses_TComboBox
+#define Uses_TComboWindow
+#define Uses_TComboItem
+#define Uses_TEvent
+#define Uses_TDrawBuffer
+#define Uses_TGroup
+#include <tvision/tv.h>
+
+#define cpComboBox "\x13\x14\x16"
+
+TComboBox::TComboBox( const TRect& bounds,
+                      TComboItem *aItems,
+                      short aFocused ) noexcept :
+    TView( bounds ),
+    focused( 0 ),
+    text( 0 ),
+    value( 0 ),
+    items( aItems ),
+    numItems( 0 )
+{
+    options |= ofSelectable | ofFirstClick;
+    eventMask |= evBroadcast;
+
+    TComboItem *p;
+    for( p = items; p != 0; p = p->next )
+        numItems++;
+
+    if( numItems > 0 )
+        {
+        if( aFocused < 0 )
+            aFocused = 0;
+        else if( aFocused >= numItems )
+            aFocused = numItems - 1;
+        focused = aFocused;
+        p = items;
+        short i;
+        for( i = 0; i < focused && p != 0; i++ )
+            p = p->next;
+        if( p != 0 )
+            {
+            text = p->text;
+            value = p->value;
+            }
+        }
+}
+
+TComboBox::~TComboBox()
+{
+    TComboItem *p = items;
+    while( p != 0 )
+        {
+        TComboItem *n = p->next;
+        delete p;
+        p = n;
+        }
+}
+
+void TComboBox::draw()
+{
+    TDrawBuffer b;
+    TColorAttr color = mapColor( (state & sfFocused) != 0 ? 2 : 1 );
+
+    b.moveChar( 0, ' ', color, size.x );
+    if( text != 0 && size.x > 3 )
+        b.moveStr( 1, text, color, size.x - 3 );
+    if( size.x > 1 )
+        b.moveChar( size.x - 2, '\x1F', mapColor(3), 1 );
+    writeLine( 0, 0, size.x, 1, b );
+}
+
+TPalette& TComboBox::getPalette() const
+{
+    static TPalette palette( cpComboBox, sizeof( cpComboBox )-1 );
+    return palette;
+}
+
+void TComboBox::focusItem( short item ) noexcept
+{
+    if( numItems == 0 )
+        return;
+    if( item < 0 )
+        item = 0;
+    else if( item >= numItems )
+        item = numItems - 1;
+    focused = item;
+
+    TComboItem *p = items;
+    short i;
+    for( i = 0; i < item && p != 0; i++ )
+        p = p->next;
+    if( p != 0 )
+        {
+        text = p->text;
+        value = p->value;
+        }
+    drawView();
+}
+
+void TComboBox::newList( TComboItem *aItems, short aFocused ) noexcept
+{
+    TComboItem *p = items;
+    while( p != 0 )
+        {
+        TComboItem *n = p->next;
+        delete p;
+        p = n;
+        }
+
+    items = aItems;
+    numItems = 0;
+    for( p = items; p != 0; p = p->next )
+        numItems++;
+
+    text = 0;
+    value = 0;
+    focused = 0;
+    if( numItems > 0 )
+        focusItem( aFocused );
+    else
+        drawView();
+}
+
+TComboWindow *TComboBox::initComboWindow( const TRect& bounds )
+{
+    return new TComboWindow( bounds, items, focused );
+}
+
+void TComboBox::handleEvent( TEvent& event )
+{
+    TView::handleEvent( event );
+    if( numItems > 0 &&
+        ( event.what == evMouseDown ||
+          ( event.what == evKeyDown &&
+            ( event.keyDown.charScan.charCode == ' ' ||
+              event.keyDown.keyCode == kbEnter ||
+              ctrlToArrow(event.keyDown.keyCode) == kbDown )
+          )
+        )
+      )
+        {
+        TRect r = getBounds();
+        r.a.y++;
+        short rows = numItems < 8 ? numItems : 8;
+        r.b.y = r.a.y + rows + 2;
+        TRect limits = owner->getExtent();
+        r.intersect( limits );
+
+        TComboWindow *win = initComboWindow( r );
+        if( win != 0 )
+            {
+            ushort c = owner->execView( win );
+            if( c == cmOK )
+                {
+                short sel = win->getSelection();
+                if( sel != focused )
+                    {
+                    focusItem( sel );
+                    message( owner, evBroadcast, cmComboBoxSelectionChanged, this );
+                    }
+                }
+            destroy( win );
+            }
+        drawView();
+        clearEvent( event );
+        }
+}


### PR DESCRIPTION
# Add TComboBox: a drop-down combo box widget

## Why

Turbo Vision has no drop-down combo box (see #173, still open with no resolution). Anyone who needs one today has to hand-roll something on top of `TListViewer`/`TMenuPopup`, as several projects already have. This adds a proper one to the library.

## What's included

- **`TComboItem`** (header-only, `dialogs.h`): a singly-linked list node with a displayed `text` and an opaque `value` (`ulong`, defaults to `0`) the programmer can use to identify the entry. Built and consumed the same way `TSItem` is for `TCluster`/`TRadioButtons`:

  ```cpp TComboItem *fruits = new TComboItem( "Apple",  1, new TComboItem( "Banana", 2, new TComboItem( "Cherry", 3, 0 ) ) ); TComboBox *combo = new TComboBox( bounds, fruits ); ```

- **`TComboBox`** (`tcombobo.cpp`): the field itself - current selection text plus a drop-down arrow. Space/Enter/Down or a mouse click opens the popup; the box owns and frees its `TComboItem` chain in its own destructor, and broadcasts a new `cmComboBoxSelectionChanged` command when the selection changes.

- **`TComboWindow`** (`tcmbowin.cpp`) and **`TComboViewer`** (`tcmbovie.cpp`): the popup itself, structured the same way `THistoryWindow`/ `THistoryViewer` are for `TInputLine`'s history button - a borderless window with a `TListViewer` subclass inside, closed with `cmOK` on double-click/Enter, `cmCancel` on Esc or a click outside. Neither of these owns the item chain (same convention as `THistoryWindow` not owning the history strings it displays).

  `TComboViewer` additionally supports incremental search: typing a letter while the popup is focused jumps to the next entry starting with it.

## Compatibility

Purely additive: new `Uses_TComboBox`/`Uses_TComboWindow`/ `Uses_TComboViewer`/`Uses_TComboItem` macros in `tv.h`, three new classes in `dialogs.h`, one new command constant (`cmComboBoxSelectionChanged = 59`, the next free slot after `cmTimerExpired`) in `views.h`. Nothing existing is renumbered or changed.

## Testing

- Full library + all bundled examples (`hello`, `tvedit`, `tvdemo`, `tvdir`, `tvforms`, `tvhc`, `mmenu`, `palette`) build clean via the normal CMake flow, no regressions.
- A standalone test project (attached separately, not part of this PR) with:
  - unit tests for `TComboBox`/`TComboViewer` construction, `focusItem`, `newList`, out-of-range clamping, and the empty-list case;
  - a Valgrind-clean check of the real construct/`destroy()` lifecycle inside a live `TApplication`;
  - an interactive demo dialog.

## Open questions for the maintainer

- Palette bytes for `TComboBox`/`TComboWindow`/`TComboViewer` currently reuse existing indices (`TInputLine`'s normal/focused text, `THistory`'s arrow colour) rather than introducing new default colours - happy to change if you'd rather they stood out visually.
- `TComboBox` only offers single selection from a static in-memory list. Editable/typeahead-filtered combos, or a variant backed by a `TCollection`, felt like a separate follow-up rather than something to bundle into an initial PR.